### PR TITLE
Adjust dependencies to avoid numba incompatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,11 +8,12 @@ version = "0.1.4"
 requires-python = ">= 3.9"
 dependencies = [
   "numpy<2",
-  "librosa<0.8",
+  "librosa>=0.8",
   "torch<2",
-  "torchlibrosa<0.0.5",
+  "torchlibrosa",
   "typer",
-  "platformdirs"
+  "platformdirs",
+  "matplotlib"
 ]
 license = "MIT"
 readme = "README.md"


### PR DESCRIPTION
- Changed to `librosa>=0.8` to avoid [this error](https://stackoverflow.com/questions/62851675/import-librosa-gives-no-module-named-numba-decorators-how-to-solve).
- Added `matplotlib` and removed version restriction on `torchlibrosa` to support newer versions of `librosa`.